### PR TITLE
Only use ScuffedShader.cs in Editor

### DIFF
--- a/ValheimExportHelper/Resources/ScuffedShaders.cs
+++ b/ValheimExportHelper/Resources/ScuffedShaders.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -34,3 +35,4 @@ public class ScuffedShaders : MonoBehaviour
     };
   }
 }
+#endif


### PR DESCRIPTION
Don't let this compile when building asset bundles as it causes errors calling editor items.