### PR TITLE
Hotfix for latest Valheim version (0.212.9 for 12.16.2022)

### DIFF
--- a/ValheimExportHelper/FixWAVs.cs
+++ b/ValheimExportHelper/FixWAVs.cs
@@ -12,13 +12,16 @@
 
     private void FixWAVFile(string filename)
     {
-      byte[] wavFile = File.ReadAllBytes(filename);
+      if (File.Exists(filename))
+      {
+        byte[] wavFile = File.ReadAllBytes(filename);
 
-      int len = wavFile.Length;
-      BitConverter.GetBytes(len - 0x08).CopyTo(wavFile, 0x04);
-      BitConverter.GetBytes(len - 0x2E).CopyTo(wavFile, 0x2A);
+        int len = wavFile.Length;
+        BitConverter.GetBytes(len - 0x08).CopyTo(wavFile, 0x04);
+        BitConverter.GetBytes(len - 0x2E).CopyTo(wavFile, 0x2A);
 
-      File.WriteAllBytes(filename, wavFile);
+        File.WriteAllBytes(filename, wavFile);
+      }
     }
   }
 }


### PR DESCRIPTION
In this patch audio clips were moved from `.wav` to `.ogg`. So trying to use `ValheimExportHelper` for ripping assets from current Valheim version actually results in `System.IO.FileNotFoundException`. Idk if we still need some fixes for audio files, but at least we can have working project with this hotfix.